### PR TITLE
CI: Only include Ruby versions in support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ todo.txt
 */**/.*.swp
 */**/*.swp
 */*/*/*.swp
+tmp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+AllCops:
+  Exclude:
+    - "tmp/**/*"
+inherit_gem:
+  barsoom_utils: shared_rubocop.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+language: ruby
+
 rvm:
-  - ree
+  - "2.7"
+  - "2.6"
+  - "2.5"
+
+cache: bundler
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in debitech_soap.gemspec
 gemspec
+
+group :development, :test do
+  gem "barsoom_utils", github: "barsoom/barsoom_utils"
+  gem "rubocop"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,41 +1,100 @@
+GIT
+  remote: https://github.com/barsoom/barsoom_utils.git
+  revision: 6fc67d60421d5c102bc88f53d033e4acad969b81
+  specs:
+    barsoom_utils (0.1.0)
+
 PATH
   remote: .
   specs:
-    debitech_soap (1.1.1)
+    debitech_soap (1.2.0)
       httpclient (>= 2.4.0)
       mumboe-soap4r (~> 1.5.8.4)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.3)
-    guard (0.8.8)
-      thor (~> 0.14.6)
-    guard-rspec (0.5.0)
-      guard (>= 0.8.4)
+    ast (2.4.0)
+    coderay (1.1.2)
+    diff-lcs (1.3)
+    ffi (1.12.2)
+    formatador (0.2.5)
+    guard (2.16.2)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
     httpclient (2.8.3)
+    jaro_winkler (1.5.4)
+    listen (3.2.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    lumberjack (1.2.4)
+    method_source (1.0.0)
     mumboe-soap4r (1.5.8.7)
       httpclient (>= 2.1.1)
-    rake (0.9.2)
-    rspec (2.7.0)
-      rspec-core (~> 2.7.0)
-      rspec-expectations (~> 2.7.0)
-      rspec-mocks (~> 2.7.0)
-    rspec-core (2.7.1)
-    rspec-expectations (2.7.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.7.0)
-    thor (0.14.6)
+    nenv (0.3.0)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    parallel (1.19.1)
+    parser (2.7.1.1)
+      ast (~> 2.4.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rainbow (3.0.0)
+    rake (13.0.1)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
+    rubocop (0.82.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rexml
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    ruby-progressbar (1.10.1)
+    shellany (0.0.1)
+    thor (1.0.1)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  barsoom_utils!
   debitech_soap!
   guard
   guard-rspec
   rake
   rspec
+  rubocop
 
 BUNDLED WITH
-   1.15.4
+   2.1.4

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.expect_with(:rspec) { |c| c.syntax = :expect }
+end


### PR DESCRIPTION
This PR brings CI up to modern Ruby versions and RSpec syntax.

## Background

Ruby 2.5-2.7 are in support. This PR changes the CI to test on those versions.

[Ruby maintenance branches web page](https://www.ruby-lang.org/en/downloads/branches/).

## Details

Also: cache bundler.

Also: use RSpec `expect` syntax.

Test suite run-time:  Total time 2 min 6 sec (previous run, which never got to the tests: 5 min 6 sec)